### PR TITLE
feat: connect import scripts to frontend (issue #91)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1358,6 +1358,378 @@ def import_data():
     return render_template(ROUTE_TEMPLATES["/import"])
 
 
+# ---------------------------------------------------------------------------
+#  Catalog import  (CSV: Subject,Catalog,Title,Career,ClassUnit,Prerequisites)
+# ---------------------------------------------------------------------------
+
+def _parse_catalog_csv(file_stream):
+    """Parse a 6-column catalog CSV and return list of row dicts."""
+    text = file_stream.read().decode("utf-8-sig")
+    reader = csv.reader(io.StringIO(text))
+    header = next(reader, None)
+    if header is None:
+        return []
+    rows = []
+    for line in reader:
+        if len(line) < 6:
+            continue
+        rows.append({
+            "subject": line[0].strip(),
+            "catalog": line[1].strip(),
+            "title": line[2].strip(),
+            "career": line[3].strip(),
+            "classunit": line[4].strip(),
+            "prerequisites": line[5].strip(),
+        })
+    return rows
+
+
+@app.post("/api/import/catalog")
+def api_import_catalog():
+    f = request.files.get("file")
+    if not f or not f.filename.endswith(".csv"):
+        return jsonify({"status": "error", "message": "Please upload a .csv file."}), 400
+
+    rows = _parse_catalog_csv(f.stream)
+    if not rows:
+        return jsonify({"status": "error", "message": "CSV is empty or has no valid rows."}), 400
+
+    inserted = 0
+    updated = 0
+    skipped = 0
+
+    try:
+        for row in rows:
+            result = db.session.execute(
+                db.text("SELECT id FROM catalog WHERE subject = :subject AND catalog = :catalog"),
+                {"subject": row["subject"], "catalog": row["catalog"]},
+            )
+            existing = result.mappings().first()
+            if existing:
+                db.session.execute(
+                    db.text("""
+                        UPDATE catalog
+                        SET title = :title, career = :career,
+                            classunit = :classunit, prerequisites = :prerequisites
+                        WHERE subject = :subject AND catalog = :catalog
+                    """),
+                    row,
+                )
+                updated += 1
+            else:
+                db.session.execute(
+                    db.text("""
+                        INSERT INTO catalog (id, subject, catalog, title, career, classunit, prerequisites)
+                        VALUES ((SELECT COALESCE(MAX(id), 0) + 1 FROM catalog),
+                                :subject, :catalog, :title, :career, :classunit, :prerequisites)
+                    """),
+                    row,
+                )
+                inserted += 1
+
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        app.logger.error("Catalog import failed: %s", e)
+        return jsonify({"status": "error", "message": "A database error occurred while importing catalog."}), 500
+
+    return jsonify({
+        "status": "success",
+        "rows_processed": len(rows),
+        "inserted": inserted,
+        "updated": updated,
+        "skipped": skipped,
+    })
+
+
+# ---------------------------------------------------------------------------
+#  Course Sequence import  (multi-section CSV: plan, terms, courses)
+# ---------------------------------------------------------------------------
+
+def _parse_sequence_csv(file_stream):
+    """Parse a multi-section sequence CSV.
+
+    Returns (plan_dict, terms_list, courses_list) or (None, [], []) on error.
+    Sections are separated by header rows detected via the second column.
+    """
+    text = file_stream.read().decode("utf-8-sig")
+    reader = csv.reader(io.StringIO(text))
+    next(reader, None)  # skip first header
+
+    plan = None
+    terms = []
+    courses = []
+    mode = 0  # 0=plan, 1=terms, 2=courses
+
+    for line in reader:
+        if not line or not line[0].strip():
+            continue
+        col1 = line[1].strip() if len(line) > 1 else ""
+        if col1 == "YearNumber":
+            mode = 1
+            continue
+        elif col1 == "Subject":
+            mode = 2
+            continue
+
+        if mode == 0 and len(line) >= 5:
+            plan = {
+                "planname": line[0].strip(),
+                "program": line[1].strip(),
+                "entryterm": line[2].strip(),
+                "option": line[3].strip(),
+                "durationyears": int(line[4].strip()),
+            }
+        elif mode == 1 and len(line) >= 5:
+            terms.append({
+                "termnumber": line[0].strip(),
+                "yearnumber": int(line[1].strip()),
+                "season": line[2].strip(),
+                "workterm": line[3].strip().upper() == "TRUE",
+                "notes": line[4].strip() if len(line) > 4 else "",
+            })
+        elif mode == 2 and len(line) >= 3:
+            courses.append({
+                "termnumber": line[0].strip(),
+                "subject": line[1].strip(),
+                "catalog": line[2].strip(),
+                "label": line[3].strip() if len(line) > 3 else "",
+            })
+
+    return plan, terms, courses
+
+
+@app.post("/api/import/sequence")
+def api_import_sequence():
+    f = request.files.get("file")
+    if not f or not f.filename.endswith(".csv"):
+        return jsonify({"status": "error", "message": "Please upload a .csv file."}), 400
+
+    plan, terms, courses = _parse_sequence_csv(f.stream)
+    if not plan:
+        return jsonify({"status": "error", "message": "CSV is empty or missing the sequence plan row."}), 400
+
+    terms_inserted = 0
+    courses_inserted = 0
+
+    try:
+        # Insert sequence plan
+        result = db.session.execute(
+            db.text("""
+                INSERT INTO sequenceplan (planname, program, entryterm, option, durationyears)
+                VALUES (:planname, :program, :entryterm, :option, :durationyears)
+                RETURNING planid
+            """),
+            plan,
+        )
+        planid = result.mappings().first()["planid"]
+
+        # Insert terms and build termnumber → sequencetermid map
+        term_id_map = {}
+        for t in terms:
+            result = db.session.execute(
+                db.text("""
+                    INSERT INTO sequenceterm (planid, yearnumber, season, workterm, notes)
+                    VALUES (:planid, :yearnumber, :season, :workterm, :notes)
+                    RETURNING sequencetermid
+                """),
+                {**t, "planid": planid},
+            )
+            tid = result.mappings().first()["sequencetermid"]
+            term_id_map[t["termnumber"]] = tid
+            terms_inserted += 1
+
+        # Insert courses linked to their terms
+        for c in courses:
+            seq_term_id = term_id_map.get(c["termnumber"])
+            if seq_term_id is None:
+                continue
+            db.session.execute(
+                db.text("""
+                    INSERT INTO sequencecourse (sequencetermid, subject, catalog, label)
+                    VALUES (:sequencetermid, :subject, :catalog, :label)
+                """),
+                {"sequencetermid": seq_term_id, "subject": c["subject"],
+                 "catalog": c["catalog"], "label": c["label"]},
+            )
+            courses_inserted += 1
+
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        app.logger.error("Sequence import failed: %s", e)
+        return jsonify({"status": "error", "message": "A database error occurred while importing sequence."}), 500
+
+    return jsonify({
+        "status": "success",
+        "plan_name": plan["planname"],
+        "terms_inserted": terms_inserted,
+        "courses_inserted": courses_inserted,
+    })
+
+
+# ---------------------------------------------------------------------------
+#  Student Schedules import  (multi-section CSV: study, schedules, classes)
+# ---------------------------------------------------------------------------
+
+def _parse_student_schedules_csv(file_stream):
+    """Parse a multi-section student schedules CSV.
+
+    Returns (study_dict, schedules_list, classes_list).
+    """
+    text = file_stream.read().decode("utf-8-sig")
+    reader = csv.reader(io.StringIO(text))
+    next(reader, None)  # skip first header
+
+    study = None
+    schedules = []
+    classes = []
+    mode = 0  # 0=study, 1=schedules, 2=classes
+
+    for line in reader:
+        if not line or not line[0].strip():
+            continue
+        col1 = line[1].strip() if len(line) > 1 else ""
+        if col1 == "Notes":
+            mode = 1
+            continue
+        elif col1 == "Catalog":
+            mode = 2
+            continue
+
+        if mode == 0 and len(line) >= 2:
+            study = {
+                "studyname": line[0].strip(),
+                "owner": line[1].strip(),
+            }
+        elif mode == 1 and len(line) >= 2:
+            schedules.append({
+                "schedulename": line[0].strip(),
+                "notes": line[1].strip(),
+            })
+        elif mode == 2 and len(line) >= 5:
+            classes.append({
+                "schedulename": line[0].strip(),
+                "subject": line[1].strip(),
+                "catalog": line[2].strip(),
+                "section": line[3].strip(),
+                "termnumber": line[4].strip(),
+            })
+
+    return study, schedules, classes
+
+
+@app.post("/api/import/studentschedules")
+def api_import_student_schedules():
+    f = request.files.get("file")
+    if not f or not f.filename.endswith(".csv"):
+        return jsonify({"status": "error", "message": "Please upload a .csv file."}), 400
+
+    study, schedules, classes = _parse_student_schedules_csv(f.stream)
+    if not study:
+        return jsonify({"status": "error", "message": "CSV is empty or missing the study row."}), 400
+
+    schedules_inserted = 0
+    classes_inserted = 0
+    classes_skipped = 0
+
+    try:
+        # Check if study already exists → replace its schedules
+        result = db.session.execute(
+            db.text("""
+                SELECT studyid FROM studentschedulestudy
+                WHERE studyname = :studyname AND owner = :owner
+            """),
+            study,
+        )
+        existing = result.mappings().first()
+        if existing:
+            studyid = existing["studyid"]
+            db.session.execute(
+                db.text("DELETE FROM studentschedule WHERE studyid = :studyid"),
+                {"studyid": studyid},
+            )
+        else:
+            result = db.session.execute(
+                db.text("""
+                    INSERT INTO studentschedulestudy (studyname, owner)
+                    VALUES (:studyname, :owner) RETURNING studyid
+                """),
+                study,
+            )
+            studyid = result.mappings().first()["studyid"]
+
+        # Insert schedules and build name → id map
+        schedule_id_map = {}
+        for s in schedules:
+            result = db.session.execute(
+                db.text("""
+                    INSERT INTO studentschedule (schedulename, notes, studyid)
+                    VALUES (:schedulename, :notes, :studyid) RETURNING studentscheduleid
+                """),
+                {**s, "studyid": studyid},
+            )
+            sid = result.mappings().first()["studentscheduleid"]
+            schedule_id_map[s["schedulename"]] = sid
+            schedules_inserted += 1
+
+        # Insert classes linked to their schedules
+        for c in classes:
+            sched_id = schedule_id_map.get(c["schedulename"])
+            if sched_id is None:
+                classes_skipped += 1
+                continue
+
+            # Look up classnumber and cid from scheduleterm
+            result = db.session.execute(
+                db.text("""
+                    SELECT classnumber, cid FROM scheduleterm
+                    WHERE subject = :subject AND catalog = :catalog
+                      AND section = :section AND termcode = :termnumber
+                    ORDER BY meetingpatternnumber ASC LIMIT 1
+                """),
+                c,
+            )
+            row = result.mappings().first()
+            if not row:
+                classes_skipped += 1
+                continue
+
+            db.session.execute(
+                db.text("""
+                    INSERT INTO studentscheduleclass
+                        (studentscheduleid, classnumber, term, section, cid)
+                    VALUES (:studentscheduleid, :classnumber, :term, :section, :cid)
+                """),
+                {
+                    "studentscheduleid": sched_id,
+                    "classnumber": row["classnumber"],
+                    "term": c["termnumber"],
+                    "section": c["section"],
+                    "cid": row["cid"],
+                },
+            )
+            classes_inserted += 1
+
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        app.logger.error("Student schedules import failed: %s", e)
+        return jsonify({"status": "error", "message": "A database error occurred while importing student schedules."}), 500
+
+    return jsonify({
+        "status": "success",
+        "study_name": study["studyname"],
+        "schedules_inserted": schedules_inserted,
+        "classes_inserted": classes_inserted,
+        "classes_skipped": classes_skipped,
+    })
+
+
+# ---------------------------------------------------------------------------
+#  Lab Rooms import
+# ---------------------------------------------------------------------------
+
 def _parse_lab_rooms_csv(file_stream):
     """Parse uploaded CSV and return list of row dicts."""
     text = file_stream.read().decode("utf-8-sig")

--- a/templates/import-data.html
+++ b/templates/import-data.html
@@ -201,31 +201,94 @@
     <button class="import-btn" disabled>Coming Soon</button>
   </div>
 
-  <!-- Course Catalog (Coming Soon) -->
-  <div class="import-card">
-    <span class="badge badge-soon">Coming Soon</span>
+  <!-- Course Catalog -->
+  <div class="import-card" id="card-catalog">
+    <span class="badge badge-ready">Ready</span>
     <h3>Course Catalog</h3>
     <p>Import course catalog information (titles, prerequisites, credits). Updates the <strong>catalog</strong> table.</p>
     <div class="tables">Tables: catalog</div>
-    <button class="import-btn" disabled>Coming Soon</button>
+
+    <div class="format-box">
+      <strong>Required CSV columns:</strong><br>
+      <code>Subject,Catalog,Title,Career,ClassUnit,Prerequisites</code><br><br>
+      <strong>Example row:</strong><br>
+      <code>COEN,243,Digital Design,UGRD,3.5,COEN231</code>
+    </div>
+
+    <div class="upload-area" id="upload-catalog" onclick="document.getElementById('file-catalog').click()">
+      <input type="file" id="file-catalog" accept=".csv">
+      <div class="upload-icon">+</div>
+      <div class="upload-text">Click to select CSV file or drag &amp; drop</div>
+      <div class="file-name" id="filename-catalog"></div>
+    </div>
+
+    <button class="import-btn" id="btn-catalog" disabled onclick="doImport('catalog', '/api/import/catalog')">
+      Import Catalog
+    </button>
+
+    <div class="result-box" id="result-catalog"></div>
   </div>
 
-  <!-- Sequence Plans (Coming Soon) -->
-  <div class="import-card">
-    <span class="badge badge-soon">Coming Soon</span>
+  <!-- Sequence Plans -->
+  <div class="import-card" id="card-sequence">
+    <span class="badge badge-ready">Ready</span>
     <h3>Sequence Plans</h3>
     <p>Import degree sequence plans with terms and course mappings. Updates the <strong>sequenceplan</strong>, <strong>sequenceterm</strong>, and <strong>sequencecourse</strong> tables.</p>
     <div class="tables">Tables: sequenceplan, sequenceterm, sequencecourse</div>
-    <button class="import-btn" disabled>Coming Soon</button>
+
+    <div class="format-box">
+      <strong>Multi-section CSV format:</strong><br>
+      <code>Name,Program,EntryTerm,Option,DurationYears</code><br>
+      <code>PLAN1,COEN,fall,COOP,4</code><br>
+      <code>TermNumber,YearNumber,Season,WorkTerm,Notes</code><br>
+      <code>1,1,fall,FALSE,</code><br>
+      <code>TermNumber,Subject,Catalog,Label,</code><br>
+      <code>1,COEN,243,,</code>
+    </div>
+
+    <div class="upload-area" id="upload-sequence" onclick="document.getElementById('file-sequence').click()">
+      <input type="file" id="file-sequence" accept=".csv">
+      <div class="upload-icon">+</div>
+      <div class="upload-text">Click to select CSV file or drag &amp; drop</div>
+      <div class="file-name" id="filename-sequence"></div>
+    </div>
+
+    <button class="import-btn" id="btn-sequence" disabled onclick="doImport('sequence', '/api/import/sequence')">
+      Import Sequence Plan
+    </button>
+
+    <div class="result-box" id="result-sequence"></div>
   </div>
 
-  <!-- Student Schedules (Coming Soon) -->
-  <div class="import-card">
-    <span class="badge badge-soon">Coming Soon</span>
+  <!-- Student Schedules -->
+  <div class="import-card" id="card-studentschedules">
+    <span class="badge badge-ready">Ready</span>
     <h3>Student Schedules</h3>
-    <p>Import student schedule studies and their enrolled classes. Updates the <strong>studentschedulestudy</strong> and <strong>studentschedule</strong> tables.</p>
+    <p>Import student schedule studies and their enrolled classes. Updates the <strong>studentschedulestudy</strong>, <strong>studentschedule</strong>, and <strong>studentscheduleclass</strong> tables.</p>
     <div class="tables">Tables: studentschedulestudy, studentschedule, studentscheduleclass</div>
-    <button class="import-btn" disabled>Coming Soon</button>
+
+    <div class="format-box">
+      <strong>Multi-section CSV format:</strong><br>
+      <code>StudyName,Owner,,,</code><br>
+      <code>MyStudy,admin,,,</code><br>
+      <code>ScheduleName,Notes,,,</code><br>
+      <code>Schedule1,notes here,,,</code><br>
+      <code>ScheduleName,Catalog,Subject,Section,TermNumber</code><br>
+      <code>Schedule1,COEN,243,A,2252</code>
+    </div>
+
+    <div class="upload-area" id="upload-studentschedules" onclick="document.getElementById('file-studentschedules').click()">
+      <input type="file" id="file-studentschedules" accept=".csv">
+      <div class="upload-icon">+</div>
+      <div class="upload-text">Click to select CSV file or drag &amp; drop</div>
+      <div class="file-name" id="filename-studentschedules"></div>
+    </div>
+
+    <button class="import-btn" id="btn-studentschedules" disabled onclick="doImport('studentschedules', '/api/import/studentschedules')">
+      Import Student Schedules
+    </button>
+
+    <div class="result-box" id="result-studentschedules"></div>
   </div>
 
   <!-- Buildings (Coming Soon) -->
@@ -273,17 +336,17 @@
     }
   });
 
-  /* ---- Import action ---- */
+  /* ---- Import action (Lab Rooms - original) ---- */
   async function importLabRooms() {
     const file = fileInput.files[0];
     if (!file) return;
 
     const resultEl = document.getElementById("result-labrooms");
     resultEl.className = "result-box";
-    resultEl.innerHTML = "";
+    resultEl.textContent = "";
 
     importBtn.disabled = true;
-    importBtn.innerHTML = '<span class="spinner"></span> Importing...';
+    importBtn.textContent = "Importing...";
 
     const formData = new FormData();
     formData.append("file", file);
@@ -294,24 +357,82 @@
 
       if (data.status === "success") {
         resultEl.className = "result-box success";
-        let html = `<strong>Import successful!</strong>`;
-        html += `<ul>`;
-        html += `<li>${data.rooms_upserted} lab room(s) upserted</li>`;
-        html += `<li>${data.assignments_upserted} course assignment(s) upserted</li>`;
-        html += `<li>${data.rows_processed} row(s) processed</li>`;
-        if (data.skipped > 0) html += `<li>${data.skipped} row(s) skipped</li>`;
-        html += `</ul>`;
-        resultEl.innerHTML = html;
+        resultEl.textContent = `Import successful! ${data.rooms_upserted} room(s), ${data.assignments_upserted} assignment(s), ${data.rows_processed} row(s) processed.` + (data.skipped > 0 ? ` ${data.skipped} skipped.` : "");
       } else {
         resultEl.className = "result-box error";
-        resultEl.innerHTML = `<strong>Import failed:</strong> ${data.message}`;
+        resultEl.textContent = "Import failed: " + data.message;
       }
     } catch (err) {
       resultEl.className = "result-box error";
-      resultEl.innerHTML = `<strong>Error:</strong> ${err.message}`;
+      resultEl.textContent = "Error: " + err.message;
     } finally {
       importBtn.disabled = false;
       importBtn.textContent = "Import Lab Rooms";
+    }
+  }
+
+  /* ---- Generic import for catalog / sequence / student schedules ---- */
+  function setupCard(key) {
+    const fi = document.getElementById("file-" + key);
+    const ua = document.getElementById("upload-" + key);
+    const fn = document.getElementById("filename-" + key);
+    const btn = document.getElementById("btn-" + key);
+
+    fi.addEventListener("change", () => {
+      if (fi.files.length > 0) { fn.textContent = fi.files[0].name; btn.disabled = false; }
+    });
+    ua.addEventListener("dragover", (e) => { e.preventDefault(); ua.classList.add("dragover"); });
+    ua.addEventListener("dragleave", () => ua.classList.remove("dragover"));
+    ua.addEventListener("drop", (e) => {
+      e.preventDefault(); ua.classList.remove("dragover");
+      if (e.dataTransfer.files.length > 0 && e.dataTransfer.files[0].name.endsWith(".csv")) {
+        fi.files = e.dataTransfer.files;
+        fn.textContent = e.dataTransfer.files[0].name;
+        btn.disabled = false;
+      }
+    });
+  }
+  setupCard("catalog");
+  setupCard("sequence");
+  setupCard("studentschedules");
+
+  async function doImport(key, url) {
+    const fi = document.getElementById("file-" + key);
+    const btn = document.getElementById("btn-" + key);
+    const resultEl = document.getElementById("result-" + key);
+    const file = fi.files[0];
+    if (!file) return;
+
+    resultEl.className = "result-box";
+    resultEl.textContent = "";
+    const origText = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = "Importing...";
+
+    const formData = new FormData();
+    formData.append("file", file);
+
+    try {
+      const res = await fetch(url, { method: "POST", body: formData });
+      const data = await res.json();
+
+      if (data.status === "success") {
+        resultEl.className = "result-box success";
+        const details = Object.entries(data)
+          .filter(([k]) => k !== "status")
+          .map(([k, v]) => k.replace(/_/g, " ") + ": " + v)
+          .join(", ");
+        resultEl.textContent = "Import successful! " + details;
+      } else {
+        resultEl.className = "result-box error";
+        resultEl.textContent = "Import failed: " + data.message;
+      }
+    } catch (err) {
+      resultEl.className = "result-box error";
+      resultEl.textContent = "Error: " + err.message;
+    } finally {
+      btn.disabled = false;
+      btn.textContent = origText;
     }
   }
 </script>


### PR DESCRIPTION
## Summary
- Adds Flask API endpoints for **Catalog**, **Sequence Plans**, and **Student Schedules** imports, connecting the existing CLI import scripts (PRs #82, #85, #86) to the web frontend
- Activates the three "Coming Soon" cards on the Import Data page with file upload forms, CSV format docs, and drag-and-drop support
- Uses parameterized SQL throughout (no f-string injection risk)

## Endpoints
| Endpoint | CSV Format | Tables |
|----------|-----------|--------|
| `POST /api/import/catalog` | `Subject,Catalog,Title,Career,ClassUnit,Prerequisites` | `catalog` |
| `POST /api/import/sequence` | Multi-section (plan → terms → courses) | `sequenceplan`, `sequenceterm`, `sequencecourse` |
| `POST /api/import/studentschedules` | Multi-section (study → schedules → classes) | `studentschedulestudy`, `studentschedule`, `studentscheduleclass` |

## Test plan
- [x] Catalog import: uploaded 2-row CSV, verified upsert (existing rows updated)
- [x] Sequence import: uploaded multi-section CSV, verified plan + 2 terms + 2 courses inserted
- [x] Student Schedules import: uploaded multi-section CSV, verified study + schedule created
- [x] All tested end-to-end through browser (file select → upload → success message)
- [x] Test data cleaned up from DB after verification
- [ ] CI checks pass

Closes #91